### PR TITLE
refactored package name for microsoft github rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ extensible framework which can be used for inserting devices into Kubernetes con
 This can be used in place of the standard Kubernetes Device Plugin architecture when greater 
 flexibility is desired over scheduling and insertion of devices into containers.
 For more information, see the main `KubeDevice` page at:
-[https://github.com/Microsoft/KubeDevice]
+[https://github.com/microsoft/KubeDevice]
 
 # Contributing
 

--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -3,7 +3,7 @@ package device
 import (
 	"plugin"
 
-	"github.com/Microsoft/KubeDevice-API/pkg/types"
+	"github.com/microsoft/KubeDevice-API/pkg/types"
 )
 
 type Mount struct {

--- a/pkg/devicescheduler/devicescheduler.go
+++ b/pkg/devicescheduler/devicescheduler.go
@@ -1,11 +1,11 @@
 package devicescheduler
 
 import (
-	"github.com/Microsoft/KubeDevice-API/pkg/types"
+	"github.com/microsoft/KubeDevice-API/pkg/types"
 )
 
 type PredicateFailureReason interface {
-GetReason() string
+	GetReason() string
 	GetInfo() (types.ResourceName, int64, int64, int64)
 }
 

--- a/pkg/resource/resourcetranslate.go
+++ b/pkg/resource/resourcetranslate.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Microsoft/KubeDevice-API/pkg/types"
-	"github.com/Microsoft/KubeDevice-API/pkg/utils"
+	"github.com/microsoft/KubeDevice-API/pkg/types"
+	"github.com/microsoft/KubeDevice-API/pkg/utils"
 )
 
 // IsGroupResourceName returns true if the resource name has the group resource prefix

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/Microsoft/KubeDevice-API/pkg/kdlog"
-	"github.com/Microsoft/KubeDevice-API/pkg/types"
+	"github.com/microsoft/KubeDevice-API/pkg/kdlog"
+	"github.com/microsoft/KubeDevice-API/pkg/types"
 )
 
 // Logb tells whether to log


### PR DESCRIPTION
This is a brute-force PR to rename all imports with upper-cased Microsoft to the new github.com/microsoft (lowercased) org.